### PR TITLE
Changes to check for response other than 200 OK

### DIFF
--- a/DetectDynamicJS.py
+++ b/DetectDynamicJS.py
@@ -74,7 +74,8 @@ class BurpExtender(IBurpExtender, IScannerCheck, IExtensionStateListener, IHttpR
         scan_issues = []
         if not self.isGet(baseRequestResponse.getRequest()):
             baseRequestResponse = self.switchMethod(baseRequestResponse)
-        if (not self.isScannableRequest(baseRequestResponse) or
+        if ((not (self.isScannableRequest(baseRequestResponse)) and
+            self.hasScriptContent(baseRequestResponse)) or
             not self.isScript(baseRequestResponse) or
             self.isProtected(baseRequestResponse)):
             return None

--- a/DetectDynamicJS.py
+++ b/DetectDynamicJS.py
@@ -345,18 +345,9 @@ class BurpExtender(IBurpExtender, IScannerCheck, IExtensionStateListener, IHttpR
         else:
             return 0
 
-    def has401StatusCode(self, requestResponse):
-        """
-        Checks if the status code of the request is 401
-        """
-        response = requestResponse.getResponse()
-        responseInfo = self._helpers.analyzeResponse(response)
-        statusCode = responseInfo.getStatusCode()
-        return statusCode == 401
-
     def hasScriptContent(self,requestResponse):
         """
-        Checks if the response of the request contains the scipt content
+        Checks if the response of the request contains the script content
         """
         nResponse = requestResponse.getResponse()
         nResponseInfo = self._helpers.analyzeResponse(nResponse)

--- a/DetectDynamicJS.py
+++ b/DetectDynamicJS.py
@@ -79,7 +79,9 @@ class BurpExtender(IBurpExtender, IScannerCheck, IExtensionStateListener, IHttpR
             self.isProtected(baseRequestResponse)):
             return None
         newRequestResponse = self.sendUnauthenticatedRequest(baseRequestResponse)
-        if(self.isScannableRequest(newRequestResponse)):
+        if((not (self.isScannableRequest(newRequestResponse)) and
+            self.hasScriptContent(newRequestResponse)) or
+            self.isScannableRequest(newRequestResponse)):
             issue = self.compareResponses(newRequestResponse, baseRequestResponse)
             if not issue:
                 return None
@@ -92,26 +94,8 @@ class BurpExtender(IBurpExtender, IScannerCheck, IExtensionStateListener, IHttpR
                 if isDynamic:
                     issue = self.reportDynamicOnly(newRequestResponse, baseRequestResponse,
                                                    secondRequestResponse)
-            scan_issues.append(issue)
+                scan_issues.append(issue)
             return scan_issues
-        else:
-            if(self.hasScriptContent(newRequestResponse)):
-                issue = self.compareResponses(newRequestResponse, baseRequestResponse)
-                if not issue:
-                    return None
-
-                if self.isScript(newRequestResponse):
-                    # sleep, in case this is a generically time stamped script
-                    sleep(1)
-                    secondRequestResponse = self.sendUnauthenticatedRequest(baseRequestResponse)
-                    isDynamic = self.compareResponses(secondRequestResponse, newRequestResponse)
-                    if isDynamic:
-                        issue = self.reportDynamicOnly(newRequestResponse, baseRequestResponse,
-                                                       secondRequestResponse)
-                    scan_issues.append(issue)
-                return scan_issues
-            else:
-                return None
 
     def sendUnauthenticatedRequest(self, requestResponse):
         """


### PR DESCRIPTION
Improvement to the plugin checks the status code of the response and does not report the issue for responses other than 200 OK (e.g. 401 Unauthorized) if the response is not a dynamic script (contribution by **Synopsys**).
